### PR TITLE
42 data label content management

### DIFF
--- a/src/app/admin/class-admin-settings.php
+++ b/src/app/admin/class-admin-settings.php
@@ -137,7 +137,7 @@ class Admin_Settings extends Base {
 
 		add_settings_field(
 			'think_tank_box_total',
-			__( 'Data Box - Total Text', 'site-functionality' ),
+			__( 'Donor Type Boxes - Total Text', 'site-functionality' ),
 			array( $this, 'render_think_tank_box_total' ),
 			$this->option_name,
 			$this->option_name . '_content_think_tank_section',
@@ -149,7 +149,7 @@ class Admin_Settings extends Base {
 
 		add_settings_field(
 			'think_tank_box_not_accepted',
-			__( 'Data Box - No Donations Accepted Text', 'site-functionality' ),
+			__( 'Donor Type Boxes - No Donations Accepted Text', 'site-functionality' ),
 			array( $this, 'render_think_tank_box_not_accepted' ),
 			$this->option_name,
 			$this->option_name . '_content_think_tank_section',
@@ -317,7 +317,7 @@ class Admin_Settings extends Base {
 		?>
 		<input type="text" name="<?php echo esc_attr( $this->option_name ); ?>[think_tank_box_total]" value="<?php echo esc_attr( $value ); ?>" class="large-text">
 		<p class="description">
-			<?php esc_html_e( 'e.g. Minimum funding to date from', 'site-functionality' ); ?>
+			<?php esc_html_e( 'Displays on a single think tank, total min donation amount for specific donor type.', 'site-functionality' ); ?>
 		</p>
 		<?php
 	}
@@ -333,7 +333,7 @@ class Admin_Settings extends Base {
 		?>
 		<input type="text" name="<?php echo esc_attr( $this->option_name ); ?>[think_tank_box_no_data]" value="<?php echo esc_attr( $value ); ?>" class="large-text">
 		<p class="description">
-			<?php esc_html_e( 'e.g. No data regarding donations from', 'site-functionality' ); ?>
+			<?php esc_html_e( 'Displays on single think tank, when no data is available for a specific donor type (in place of total min amount for donor type).', 'site-functionality' ); ?>
 		</p>
 		<?php
 	}
@@ -349,7 +349,7 @@ class Admin_Settings extends Base {
 		?>
 		<input type="text" name="<?php echo esc_attr( $this->option_name ); ?>[think_tank_box_not_accepted]" value="<?php echo esc_attr( $value ); ?>" class="large-text">
 		<p class="description">
-			<?php esc_html_e( 'e.g. Did not accept any donations from', 'site-functionality' ); ?>
+			<?php esc_html_e( 'Displays on single think tank when donations aren\'t accepted for a specific donor type  (in place of total min amount for donor type). ', 'site-functionality' ); ?>
 		</p>
 		<?php
 	}
@@ -365,7 +365,7 @@ class Admin_Settings extends Base {
 		?>
 		<input type="text" name="<?php echo esc_attr( $this->option_name ); ?>[think_tank_all_no_data]" value="<?php echo esc_attr( $value ); ?>" class="large-text">
 		<p class="description">
-			<?php esc_html_e( 'e.g. No donation data available from this think tank.', 'site-functionality' ); ?>
+			<?php esc_html_e( 'Displays on single think tank when no donation data is available for any of the donor types (in place of individual donor type boxes).', 'site-functionality' ); ?>
 		</p>
 		<?php
 	}
@@ -381,7 +381,7 @@ class Admin_Settings extends Base {
 		?>
 		<input type="text" name="<?php echo esc_attr( $this->option_name ); ?>[think_tank_total_text]" value="<?php echo esc_attr( $value ); ?>" class="large-text">
 		<p class="description">
-			<?php esc_html_e( 'e.g. Minimum amount received', 'site-functionality' ); ?>
+			<?php esc_html_e( 'Displays on single think tank, next to the total min donation amount.', 'site-functionality' ); ?>
 		</p>
 		<?php
 	}
@@ -397,7 +397,7 @@ class Admin_Settings extends Base {
 		?>
 		<input type="text" name="<?php echo esc_attr( $this->option_name ); ?>[think_tank_no_data_text]" value="<?php echo esc_attr( $value ); ?>" class="large-text">
 		<p class="description">
-			<?php esc_html_e( 'e.g. This think tank has not provided data regarding its donations.', 'site-functionality' ); ?>
+			<?php esc_html_e( 'Displays on single think tank when no donation data is available (in place of table).', 'site-functionality' ); ?>
 		</p>
 		<?php
 	}
@@ -413,7 +413,7 @@ class Admin_Settings extends Base {
 		?>
 		<input type="text" name="<?php echo esc_attr( $this->option_name ); ?>[donor_total_text]" value="<?php echo esc_attr( $value ); ?>" class="large-text">
 		<p class="description">
-			<?php esc_html_e( 'e.g. Minimum contributions', 'site-functionality' ); ?>
+			<?php esc_html_e( 'Displays on single donor next to total min amount donated.', 'site-functionality' ); ?>
 		</p>
 		<?php
 	}
@@ -429,7 +429,7 @@ class Admin_Settings extends Base {
 		?>
 		<input type="text" name="<?php echo esc_attr( $this->option_name ); ?>[no_data]" value="<?php echo esc_attr( $value ); ?>" class="large-text">
 		<p class="description">
-			<?php esc_html_e( 'Text that displays in place of amount when think tank does not accept donations from this type of donor.', 'site-functionality', 'site-functionality' ); ?>
+			<?php esc_html_e( 'Displays in tables in place of amount when actual amount is not known.', 'site-functionality', 'site-functionality' ); ?>
 		</p>
 		<?php
 	}
@@ -445,7 +445,7 @@ class Admin_Settings extends Base {
 		?>
 		<input type="text" name="<?php echo esc_attr( $this->option_name ); ?>[not_accepted]" value="<?php echo esc_attr( $value ); ?>" class="large-text">
 		<p class="description">
-			<?php esc_html_e( 'Text that displays in place of amount when think tank does not accept donations from this type of donor.', 'site-functionality', 'site-functionality' ); ?>
+			<?php esc_html_e( 'Displays in tables in place of amount when think tank does not accept donations from this type of donor.', 'site-functionality', 'site-functionality' ); ?>
 		</p>
 		<?php
 	}
@@ -461,7 +461,7 @@ class Admin_Settings extends Base {
 		?>
 		<input type="text" name="<?php echo esc_attr( $this->option_name ); ?>[unknown_amount]" value="<?php echo esc_attr( $value ); ?>" class="large-text">
 		<p class="description">
-			<?php esc_html_e( 'Text that displays in amount when specific donation amount is unknown.', 'site-functionality' ); ?>
+			<?php esc_html_e( 'Displays in tables in place of amount when specific donation amount is unknown.', 'site-functionality' ); ?>
 		</p>
 		<?php
 	}

--- a/src/app/admin/class-admin-settings.php
+++ b/src/app/admin/class-admin-settings.php
@@ -160,6 +160,18 @@ class Admin_Settings extends Base {
 		);
 
 		add_settings_field(
+			'think_tank_box_no_data',
+			__( 'Donor Type Boxes - No Donation Data Available', 'site-functionality' ),
+			array( $this, 'render_think_tank_box_no_data' ),
+			$this->option_name,
+			$this->option_name . '_content_think_tank_section',
+			array(
+				'label_for'   => 'think_tank_box_no_data',
+				'description' => __( 'e.g. No dononation data available for', 'site-functionality' ),
+			)
+		);
+
+		add_settings_field(
 			'think_tank_all_no_data',
 			__( 'No Donation Info Available', 'site-functionality' ),
 			array( $this, 'render_think_tank_all_no_data' ),
@@ -192,6 +204,30 @@ class Admin_Settings extends Base {
 			array(
 				'label_for'   => 'think_tank_no_data_text',
 				'description' => __( 'e.g. This think tank has not provided data regarding its donations.', 'site-functionality' ),
+			)
+		);
+
+		add_settings_field(
+			'think_tank_none_accepted_text',
+			__( 'None Accepted Text', 'site-functionality' ),
+			array( $this, 'render_think_tank_none_accepted_text' ),
+			$this->option_name,
+			$this->option_name . '_content_think_tank_section',
+			array(
+				'label_for'   => 'think_tank_none_accepted_text',
+				'description' => __( 'e.g. This think tank does not accept donations from any of the donor types.', 'site-functionality' ),
+			)
+		);
+
+		add_settings_field(
+			'think_tank_is_transparent_text',
+			__( 'Is Transparent Text', 'site-functionality' ),
+			array( $this, 'render_think_tank_is_transparent_text' ),
+			$this->option_name,
+			$this->option_name . '_content_think_tank_section',
+			array(
+				'label_for'   => 'think_tank_is_transparent_text',
+				'description' => __( 'e.g. Think tank doesn\'t accept donations from any of the donor types and has transparency score 4+.', 'site-functionality' ),
 			)
 		);
 
@@ -398,6 +434,38 @@ class Admin_Settings extends Base {
 		<input type="text" name="<?php echo esc_attr( $this->option_name ); ?>[think_tank_no_data_text]" value="<?php echo esc_attr( $value ); ?>" class="large-text">
 		<p class="description">
 			<?php esc_html_e( 'Displays on single think tank when no donation data is available (in place of table).', 'site-functionality' ); ?>
+		</p>
+		<?php
+	}
+
+	/**
+	 * Outputs the HTML for the field.
+	 *
+	 * @return void
+	 */
+	public function render_think_tank_none_accepted_text(): void {
+		$options = get_option( $this->option_name );
+		$value   = isset( $options['think_tank_none_accepted_text'] ) ? $options['think_tank_none_accepted_text'] : '';
+		?>
+		<input type="text" name="<?php echo esc_attr( $this->option_name ); ?>[think_tank_none_accepted_text]" value="<?php echo esc_attr( $value ); ?>" class="large-text">
+		<p class="description">
+			<?php esc_html_e( 'Displays on single think thank when donations aren\'t accepted for any of the donor types (in place of table). ', 'site-functionality', 'site-functionality' ); ?>
+		</p>
+		<?php
+	}
+
+		/**
+	 * Outputs the HTML for the field.
+	 *
+	 * @return void
+	 */
+	public function render_think_tank_is_transparent_text(): void {
+		$options = get_option( $this->option_name );
+		$value   = isset( $options['think_tank_is_transparent_text'] ) ? $options['think_tank_is_transparent_text'] : '';
+		?>
+		<input type="text" name="<?php echo esc_attr( $this->option_name ); ?>[think_tank_is_transparent_text]" value="<?php echo esc_attr( $value ); ?>" class="large-text">
+		<p class="description">
+			<?php esc_html_e( 'Displays on single think thank when donations aren\'t accepted for any of the donor types and has transparency score 4+ (in place of table). ', 'site-functionality', 'site-functionality' ); ?>
 		</p>
 		<?php
 	}

--- a/src/app/admin/class-admin-settings.php
+++ b/src/app/admin/class-admin-settings.php
@@ -119,13 +119,13 @@ class Admin_Settings extends Base {
 			$this->option_name
 		);
 
-		add_settings_field(
-			'default_year',
-			__( 'Default Year', 'site-functionality' ),
-			array( $this, 'render_default_year' ),
-			$this->option_name,
-			$this->option_name . '_section'
-		);
+		// add_settings_field(
+		// 	'default_year',
+		// 	__( 'Default Year', 'site-functionality' ),
+		// 	array( $this, 'render_default_year' ),
+		// 	$this->option_name,
+		// 	$this->option_name . '_section'
+		// );
 
 		add_settings_field(
 			'rows_per_page',

--- a/src/app/integrations/wp-import/class-actions.php
+++ b/src/app/integrations/wp-import/class-actions.php
@@ -466,6 +466,7 @@ class Actions extends Base {
 		$amount_min  = wp_list_pluck( $data, 'amount_min' );
 		$amount_max  = wp_list_pluck( $data, 'amount_max' );
 		$amount_calc = wp_list_pluck( $data, 'amount_calc' );
+		$disclosed   = wp_list_pluck( $data, 'disclosed' );
 		$years       = array_filter(
 			array_unique( wp_list_pluck( $data, 'year' ) ),
 			function ( $year ) {


### PR DESCRIPTION
- [Update text for clarity](https://github.com/misfist/site-functionality-think-tank-transparency/commit/14650dd3177bdbc15cf79723b017a4402b95f785)
   - Descriptions and labels updated to help identify which fields are which
- [Add fields](https://github.com/misfist/site-functionality-think-tank-transparency/commit/cab458cc913c6ced4772b30a2abab6d74e217948)
   - Individual no data box text
   - None accepted text
   - Is transparent text
- [Remove default year](https://github.com/misfist/site-functionality-think-tank-transparency/commit/783a53a8b5221b6c258525ddc5696c4ce7daa165)
   - No longer needed (I hope)