### PR TITLE
Bugfix - Only render if value present

### DIFF
--- a/src/app/post-types/class-donor.php
+++ b/src/app/post-types/class-donor.php
@@ -294,7 +294,7 @@ class Donor extends Post_Type {
 			</thead>
 			<tbody>
 				<tr>
-					<td><?php echo sprintf( '$%s', number_format( $amount ) ); ?></td>
+					<td><?php echo sprintf( '$%s', ( $amount ) ? number_format( $amount ) : '' ); ?></td>
 					<td><?php echo $donor_type; ?></td>
 					<td><?php echo $parent_obj->post_title; ?></td>
 				</tr>


### PR DESCRIPTION
```
PHP Fatal error:  Uncaught TypeError: number_format(): Argument #1 ($num) must be of type float, string given in /nas/content/live/fptpdev/wp-content/plugins/site-functionality/src/app/post-types/class-donor.php:297 Stack trace:
#0 /nas/content/live/fptpdev/wp-content/plugins/site-functionality/src/app/post-types/class-donor.php(297): number_format('') #1 /nas/content/live/fptpdev/wp-admin/includes/template.php(1453): Site_Functionality\App\Post_Types\Donor->render_meta_box(Object(WP_Post), Array) #2 /nas/content/live/fptpdev/wp-admin/edit-form-advanced.php(744): do_meta_boxes(Object(WP_Screen), 'advanced', Object(WP_Post)) #3 /nas/content/live/fptpdev/wp-admin/post.php(206): require('/nas/content/li...') #4 {main}
  thrown in /nas/content/live/fptpdev/wp-content/plugins/site-functionality/src/app/post-types/class-donor.php on line 297
```